### PR TITLE
Namespace and plugins_registry Directory

### DIFF
--- a/deploy/kubernetes/csi-cvmfsplugin.yaml
+++ b/deploy/kubernetes/csi-cvmfsplugin.yaml
@@ -73,7 +73,7 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
-            type: Directory
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cvmfs

--- a/example/plugin-deploy.sh
+++ b/example/plugin-deploy.sh
@@ -8,7 +8,7 @@ fi
 
 cd "$deployment_base" || exit 1
 
-objects=(csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac csi-cvmfsplugin-attacher csi-cvmfsplugin-provisioner csi-cvmfsplugin)
+objects=(namespace csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac csi-cvmfsplugin-attacher csi-cvmfsplugin-provisioner csi-cvmfsplugin)
 
 for obj in ${objects[@]}; do
 	kubectl create -f "./$obj.yaml"

--- a/example/plugin-teardown.sh
+++ b/example/plugin-teardown.sh
@@ -8,7 +8,7 @@ fi
 
 cd "$deployment_base" || exit 1
 
-objects=(csi-cvmfsplugin-attacher csi-cvmfsplugin-provisioner csi-cvmfsplugin csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac)
+objects=(csi-cvmfsplugin-attacher csi-cvmfsplugin-provisioner csi-cvmfsplugin csi-attacher-rbac csi-provisioner-rbac csi-nodeplugin-rbac namespace)
 
 for obj in ${objects[@]}; do
 	kubectl delete -f "./$obj.yaml"


### PR DESCRIPTION
Small changes I had to make to have the CVMFS-CSI work out of the box. I believe the `plugins_registry` change might only be needed for some K8S versions. The namespace is just to not have to create it manually when testing with the scripts.
Note: the default repository did not work when I first tried setting it up, however the setup did work with our Galaxy Project (https://galaxyproject.org/) repository: https://github.com/almahmoud/cvmfs-csi/tree/v1-galaxy