### PR TITLE
default.local precedence for cache base

### DIFF
--- a/pkg/cvmfs/cvmfsconf.go
+++ b/pkg/cvmfs/cvmfsconf.go
@@ -13,13 +13,14 @@ const (
 
 const repoConf = `
 {{fileContents "/etc/cvmfs/default.conf"}}
+
+CVMFS_CACHE_BASE={{cacheBase .VolumeId}}
+
 {{fileContents "/etc/cvmfs/default.local"}}
 
 {{if .Proxy}}
 CVMFS_HTTP_PROXY={{.Proxy}}
 {{end}}
-
-CVMFS_CACHE_BASE={{cacheBase .VolumeId}}
 
 {{if .Hash}}
 CVMFS_ROOT_HASH={{.Hash}}


### PR DESCRIPTION
I do not fully understand how the cache volume is being handled in `volume.go`, so more changes might be needed (specifically to not create the cache volumes when the user does not intend to use them), but the basic thought behind this is that since the user specifies their own `default.local` through a configmap, those values should probably take precedence over defaults. I only moved the cache portion because it was relevant to our setup, but I am wondering if the other values currently overwriting `default.local` should be between `default.conf` and `default.local` as well.
P.S. This came about in the context of deploying with a helm chart, and trying to have the setup configurable through `values.yaml`, but I am separating the PR's given that this could be relevant regardless of the chart.