### PR TITLE
Helm Chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,23 @@
+# CVMFS-CSI Helm Chart
+
+This is an initial version of a CVMFS-CSI helm chart.
+
+## Basic Usage
+
+1. Change the configuration options in the `values.yaml` file for your CVMFS setup.
+In principle, the chart should be fully configurable through the `values.yaml` file.
+For more information on the different possible ways to specify values, see: https://helm.sh/docs/helm/#helm-install
+
+2. To install the chart with the release name `my-release` in the `cvmfs` namespace:
+```
+helm install --name my-release --namespace cvmfs -f mynewvalues.yaml ./cvmfs-csi
+```
+If no name is specified, helm will create a random release name.
+
+3. To delete a release:
+```
+helm delete --purge my-release
+```
+
+For more advanced options and information, visit the helm docs:
+https://helm.sh/docs/helm/

--- a/deploy/helm/cvmfs-csi/Chart.yaml
+++ b/deploy/helm/cvmfs-csi/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to deploy the CVMFS-CSI Plugin
+name: cvmfs-csi
+version: 1.0.0

--- a/deploy/helm/cvmfs-csi/templates/configmap-cvmfs-config.yaml
+++ b/deploy/helm/cvmfs-csi/templates/configmap-cvmfs-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cvmfs-configmap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- range $key, $entry := .Values.configs -}}
+  {{- if $entry.contents -}}
+  {{- $key | nindent 2 }}: |
+    {{- tpl $entry.contents $ | nindent 4 -}}
+    {{- end }}
+  {{- end }}

--- a/deploy/helm/cvmfs-csi/templates/csi-attacher-rbac.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-attacher-rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cvmfs-attacher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-external-attacher-runner
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-attacher-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: cvmfs-attacher
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cvmfs-external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin-attacher.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin-attacher.yaml
@@ -1,0 +1,55 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cvmfsplugin-attacher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin-attacher
+spec:
+  selector:
+    app: csi-cvmfsplugin-attacher
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-cvmfsplugin-attacher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: "csi-cvmfsplugin-attacher"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        app: csi-cvmfsplugin-attacher
+    spec:
+      serviceAccount: cvmfs-attacher
+      containers:
+        - name: csi-attacher
+          image: {{ .Values.csiAttacher.image }}
+          args:
+            {{- range $arg := .Values.csiAttacher.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: {{ .Values.csiPlugin.pluginDirectory }}/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: {{ .Values.csiPlugin.pluginDirectory }}
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: {{ .Values.csiPlugin.pluginDirectory }}
+            type: DirectoryOrCreate

--- a/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin-provisioner.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin-provisioner.yaml
@@ -1,0 +1,55 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cvmfsplugin-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin-provisioner
+spec:
+  selector:
+    app: csi-cvmfsplugin-provisioner
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-cvmfsplugin-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: "csi-cvmfsplugin-provisioner"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        app: csi-cvmfsplugin-provisioner
+    spec:
+      serviceAccount: cvmfs-provisioner
+      containers:
+        - name: csi-provisioner
+          image: {{ .Values.csiProvisioner.image }}
+          args:
+            {{- range $arg := .Values.csiProvisioner.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: {{ .Values.csiPlugin.pluginDirectory }}/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: {{ .Values.csiPlugin.pluginDirectory }}
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: {{ .Values.csiPlugin.pluginDirectory }}
+            type: DirectoryOrCreate

--- a/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-cvmfsplugin.yaml
@@ -1,0 +1,103 @@
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: csi-cvmfsplugin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: csi-cvmfsplugin
+  template:
+    metadata:
+      labels:
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        app: csi-cvmfsplugin
+    spec:
+      serviceAccount: cvmfs-nodeplugin
+      hostNetwork: true
+      containers:
+        - name: csi-driver-registrar
+          image: {{ .Values.csiPlugin.nodeDriverImage }}
+          args:
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path={{ .Values.csiPlugin.pluginDirectory }}/csi.sock"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-cvmfsplugin /registration/csi-cvmfsplugin-reg.sock"]
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-cvmfsplugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{ .Values.csiPlugin.image }}
+          args :
+            {{- range $arg := .Values.csiPlugin.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:/{{ .Values.csiPlugin.pluginDirectory }}/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: {{ .Values.csiPlugin.pluginDirectory }}
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - mountPath: /sys
+              name: host-sys
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: host-dev
+              mountPath: /dev
+            {{- range $key, $entry := .Values.configs }}
+            - name: cvmfs-config
+              mountPath: /etc/cvmfs/{{ $entry.mountPath }}
+              subPath: {{ $key }}
+            {{- end }}
+            - name: cvmfs-cache
+              mountPath: {{ .Values.cache.mountPath }}
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.csiPlugin.pluginDirectory }}
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-dev
+          hostPath:
+            path: /dev
+        - name: cvmfs-config
+          configMap:
+            name: cvmfs-configmap
+        - name: cvmfs-cache
+          persistentVolumeClaim:
+            claimName: cvmfs-cache-pvc

--- a/deploy/helm/cvmfs-csi/templates/csi-nodeplugin-rbac.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-nodeplugin-rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cvmfs-nodeplugin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-nodeplugin
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-nodeplugin
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: cvmfs-nodeplugin
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cvmfs-nodeplugin
+  apiGroup: rbac.authorization.k8s.io
+
+  

--- a/deploy/helm/cvmfs-csi/templates/csi-provisioner-rbac.yaml
+++ b/deploy/helm/cvmfs-csi/templates/csi-provisioner-rbac.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cvmfs-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-provisioner-runner
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+   
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cvmfs-provisioner-role
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: cvmfs-provisioner
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cvmfs-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/cvmfs-csi/templates/pv-cache.yaml
+++ b/deploy/helm/cvmfs-csi/templates/pv-cache.yaml
@@ -1,0 +1,36 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: cvmfs-cache-pv
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin
+spec:
+  storageClassName: {{ .Values.cache.storageClassName }}
+  capacity:
+    storage: {{ .Values.cache.size }}Mi
+  accessModes:
+    - {{ .Values.cache.accessMode }}
+  hostPath:
+    path: {{ .Values.cache.hostPath | quote }}
+
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: cvmfs-cache-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin
+spec:
+  storageClassName: {{ .Values.cache.storageClassName }}
+  accessModes:
+    - {{ .Values.cache.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.cache.size }}Mi

--- a/deploy/helm/cvmfs-csi/templates/storageclass-cvmfs-data.yaml
+++ b/deploy/helm/cvmfs-csi/templates/storageclass-cvmfs-data.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs-gxy-data
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin
+provisioner: csi-cvmfsplugin
+parameters:
+  repository: data.galaxyproject.org

--- a/deploy/helm/cvmfs-csi/templates/storageclass-cvmfs-main.yaml
+++ b/deploy/helm/cvmfs-csi/templates/storageclass-cvmfs-main.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs-gxy-main
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: csi-cvmfsplugin
+provisioner: csi-cvmfsplugin
+parameters:
+  repository: main.galaxyproject.org

--- a/deploy/helm/cvmfs-csi/templates/storageclasses.yaml
+++ b/deploy/helm/cvmfs-csi/templates/storageclasses.yaml
@@ -1,0 +1,16 @@
+{{- range $key, $rep := .Values.repositories -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $key }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    app: csi-cvmfsplugin
+provisioner: csi-cvmfsplugin
+parameters:
+  repository: {{ $rep }}
+
+---
+{{ end }}

--- a/deploy/helm/cvmfs-csi/values.yaml
+++ b/deploy/helm/cvmfs-csi/values.yaml
@@ -1,0 +1,79 @@
+# Default values for galaxy-cvmfs-csi.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# All contents will be run through tpl
+# All mountPaths are relative to /etc/cvmfs/
+configs:
+  defaultLocal:
+    mountPath: default.local
+    contents: |
+      CVMFS_SERVER_URL="http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@;http://cernvmfs.gridpp.rl.ac.uk/cvmfs/@fqrn@;http://cvmfs.racf.bnl.gov/cvmfs/@fqrn@;http://cvmfs.fnal.gov/cvmfs/@fqrn@"
+      CVMFS_KEYS_DIR=/etc/cvmfs/keys/cern.ch
+      CVMFS_USE_GEOAPI=yes
+
+      CVMFS_HTTP_PROXY="http://ca-proxy.cern.ch:3128"
+      CVMFS_QUOTA_LIMIT=20000
+      # It is advised to change these configs in the cache section of the helm values
+      CVMFS_QUOTA_LIMIT={{ .Values.cache.size }}
+      CVMFS_CACHE_BASE={{ .Values.cache.mountPath }}
+  firstKey:
+    mountPath: keys/cern.ch/my-first-key.pub
+    contents: |
+      -----BEGIN PUBLIC KEY-----
+      AAAAB3NzaC1yc2EAAAADAQABAAABAQCwG9Gtd95SaC6EmcYGzhBve1emIg5z8ReR
+      oVUb0hkuguwjY61AOWEwGfmOVsqrGg1v97Tu8i0O1gCahdUYDZK7hZ9ad82g3dbh
+      N2Fe0bikMTyObG0EyWpjQRXHYpypImBWKE6f2xMtYpr7rNjBUhOJbaspG9Q8Em+R
+      McqRiCM2/MrBFfy4oe32z0ivBK8kfI1jYHOq6InT/LJ7MMPx0XCPOCVD+etYSz89
+      XDUL0dlqrH8HuuVkMxDRbjq4U0ZXeF5XhjL/b3EU9lgNF3KMCkmPGTptWv554CJ0
+      tM5JavKILEYnZDUT14XTJH7bBNx4a90gHEz33zaSoS6vgZ3oonuv
+      -----END PUBLIC KEY-----
+  secondKey:
+    mountPath: keys/cern.ch/my-second-key.pub
+    contents: |
+      -----BEGIN PUBLIC KEY-----
+      AAAAB3NzaC1yc2EAAAADAQABAAABAQCwG9Gtd95SaC6EmcYGzhBve1emIg5z8ReR
+      oVUb0hkuguwjY61AOWEwGfmOVsqrGg1v97Tu8i0O1gCahdUYDZK7hZ9ad82g3dbh
+      N2Fe0bikMTyObG0EyWpjQRXHYpypImBWKE6f2xMtYpr7rNjBUhOJbaspG9Q8Em+R
+      McqRiCM2/MrBFfy4oe32z0ivBK8kfI1jYHOq6InT/LJ7MMPx0XCPOCVD+etYSz89
+      XDUL0dlqrH8HuuVkMxDRbjq4U0ZXeF5XhjL/b3EU9lgNF3KMCkmPGTptWv554CJ0
+      tM5JavKILEYnZDUT14XTJH7bBNx4a90gHEz33zaSoS6vgZ3oonuv
+      -----END PUBLIC KEY-----
+
+# A storage class will be created for each repository
+repositories:
+  # The key will be used for the storage class name
+  # The value will be used for the repository
+  storageClassName: my-repostory.name
+
+cache:
+  storageClassName: manual
+  accessMode: ReadWriteMany
+  # size in Mi, will propagate to both default.local and PV/PVC size
+  size: 1000
+  hostPath: /tmp/k8s/volumes/cvmfs/cache
+  mountPath: /mnt/cvmfs/cache
+
+# Advanced settings
+# Changing these settings is not advised unless you know what you are doing
+csiPlugin:
+  image: gitlab-registry.nautilus.optiputer.net/prp/cvmfs-csi:latest
+  args:
+    - "--nodeid=$(NODE_ID)"
+    - "--endpoint=$(CSI_ENDPOINT)"
+    - "--v=5"
+    - "--drivername=csi-cvmfsplugin"
+  pluginDirectory: /var/lib/kubelet/plugins/csi-cvmfsplugin
+  nodeDriverImage: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+csiAttacher:
+  image: quay.io/k8scsi/csi-attacher:v1.0.1
+  args:
+    - "--v=5"
+    - "--csi-address=$(ADDRESS)"
+csiProvisioner:
+  image: quay.io/k8scsi/csi-provisioner:v1.0.1
+  args:
+    - "--provisioner=csi-cvmfsplugin"
+    - "--csi-address=$(ADDRESS)"
+    - "--v=5"
+


### PR DESCRIPTION
We created a helm chart for our Galaxy CVMFS deployment, and I thought it might be helpful for other people who are deploying the CSI plugin. I reverted back to mock configs for the PR, but in theory, the chart can be used for any repository by only changing `values.yaml`